### PR TITLE
Temporarily disable sync PRs from the translation bot in this repository

### DIFF
--- a/translation-bot.json
+++ b/translation-bot.json
@@ -1,0 +1,3 @@
+{
+    "disabled": true
+}


### PR DESCRIPTION
This PR adds a small config file for the bot, which will make it stop submitting daily sync PRs (see [Bot configuration](https://github.com/solidity-docs/translation-guide#bot-configuration)).

I'd recommend merging it if your plan is to get a complete translation of 0.8.16 done first, tag it and only then proceed with later versions. In that case, once you have 0.8.16 tagged, you should either re-enable the bot or let me know to manually create a sync PR for 0.8.17 (though I hope that by then this will be automated in some way). Re-enabling the bot will give you updates to whatever version is in the main repo (which will may include changes from multiple released versions as well as any unreleased changes) while a manual PR for 0.8.17 will bring you exactly to that version.

On the other hand, if you prefer to catch up with latest version of main docs and want to get latest updates as they come, feel free to close this PR.