### PR TITLE
Fix sphinx-a4doc version to 1.3.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 sphinx_rtd_theme>=0.5.2
 
 pygments-lexer-solidity>=0.7.0
-sphinx-a4doc>=1.2.1
+sphinx-a4doc==1.3.0
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0


### PR DESCRIPTION
Workaround for `sphinx-a4doc >= 1.4.0` breaking change (https://github.com/ethereum/solidity/issues/13820)