### PR TITLE
Add readthedocs.yml configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+  - epub
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
According to [this blog post from read-the-docs](https://blog.readthedocs.com/migrate-configuration-v2/), it will start requiring a `.readthedocs.yml` configuration file for all projects in order to build documentation successfully. So we need to migrate to it.

We already have the configuration file in the `develop` branch, but it is excluded from the sync PRs (see: https://github.com/solidity-docs/.github/blob/main/scripts/pull-and-resolve-english-changes.sh#L28). We may also need to add it there, so other documentation repositories can get the configuration file when building the next release :)

It should also fix https://github.com/solidity-docs/zh-chinese/issues/240