### PR TITLE
Hotfix docutils set_class method

### DIFF
--- a/docs/ext/remix_code_links.py
+++ b/docs/ext/remix_code_links.py
@@ -27,10 +27,10 @@ def remix_code_url(source_code, language, solidity_version):
 
 def build_remix_link_node(url):
     reference_node = docutils.nodes.reference('', 'open in Remix', internal=False, refuri=url, target='_blank')
-    reference_node.set_class('remix-link')
+    reference_node['classes'].append('remix-link')
 
     paragraph_node = docutils.nodes.paragraph()
-    paragraph_node.set_class('remix-link-container')
+    paragraph_node['classes'].append('remix-link-container')
     paragraph_node.append(reference_node)
     return paragraph_node
 


### PR DESCRIPTION
See: https://github.com/ethereum/solidity/pull/14706 and success build here: https://app.readthedocs.org/projects/solidity-docs-chinese/builds/24716233/

Note that this may generate conflicts when you start translating Solidity version `0.8.24`, since this fix was applied upstream in that version. So you will need to resolve such conflict when the time comes :)